### PR TITLE
Add configurable A-share stock screener with AkShare/Tushare providers, MACD/MA/EPS filters, caching and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,129 @@
-# Your GitHub Learning Lab Repository for Introducing GitHub
+# 中国A股股票筛选软件（Python 3.11）
 
-Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.
+本项目是面向中国A股（上交所/深交所/北交所）的批量筛选工具，支持多周期 MACD、EPS 增长、估值、市值、均线条件等配置化筛选，并输出 CSV/Excel/HTML 报告。
 
-Oh! I haven't introduced myself...
+## 功能概览
 
-I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey to learn and master the various topics covered in this course. I will be using Issue and Pull Request comments to communicate with you. In fact, I already added an issue for you to check out.
+- 多周期 MACD：季度线、月线、周线、日线（默认日线不作为过滤）
+- 市值过滤：总市值 < 1000亿人民币（可配置字段口径）
+- EPS（季度）环比增长且盈利（允许上一季度为负、本季度转正）
+- 均线条件（如 MA20/MA60 排列、股价站上均线）
+- 并发筛选、缓存、日志与进度条
+- 可选 HTML 报告
 
-![issue tab](https://lab.github.com/public/images/issue_tab.png)
+## 安装
 
-I'll meet you over there, can't wait to get started!
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
-This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+## 快速运行
+
+```bash
+python -m screener run --config config.example.yaml
+```
+
+可覆盖参数：
+
+```bash
+python -m screener run --config config.example.yaml --max-workers 16 --use-cache false --export csv,xlsx
+```
+
+## 配置说明
+
+配置文件为 `config.example.yaml`，其中关键字段：
+
+- `data.provider`: `akshare` / `tushare` / `auto`
+- `data.tushare_token`: 若填写则支持使用 Tushare
+- `market_cap.field`: 默认 `total_market_cap`，亦可选择 `float_market_cap`
+- `macd_filters.enable_daily_filter`: 日线过滤开关（默认关闭）
+- `moving_average`: 均线配置与排列关系
+- `score_weights`: 评分权重
+
+## 数据源与字段口径
+
+### AkShare（默认）
+- 行情：`stock_zh_a_hist`
+- 市值：`stock_zh_a_spot_em`（字段包含 `总市值`、`流通市值`）
+- 财务：`stock_financial_analysis_indicator`
+
+### Tushare（可选）
+- 需要 `tushare_token`
+- 市值字段 `total_mv`、`circ_mv` 需要换算（万元 -> 元）
+
+字段映射在代码中实现，位置：
+- `screener/data/akshare_provider.py`
+- `screener/data/tushare_provider.py`
+
+## 输出
+
+默认输出到 `output/`：
+
+- `screener_results.csv`
+- `screener_results.xlsx`
+- `screener_results.html`
+
+输出字段包括：
+- 代码、名称、市场、总市值
+- 季/月/周 MACD（DIF/DEA/HIST）与归一化值
+- EPS 最新/上一季度，净利润（如可用）
+- MA20/MA60 等均线与过滤结果
+- 信号评分（按权重配置）
+
+## 常见问题
+
+1. **AkShare 无法访问**：请确认网络可用，或切换使用 Tushare。
+2. **字段缺失**：财务字段缺失时，会自动降级为仅 EPS 过滤。
+3. **停牌/退市导致无数据**：工具会跳过该股票而不导致整体崩溃。
+
+## 测试
+
+```bash
+pytest
+```
+
+## 目录结构
+
+```
+.
+├── config.example.yaml
+├── requirements.txt
+├── screener
+│   ├── __init__.py
+│   ├── __main__.py
+│   ├── app
+│   │   ├── __init__.py
+│   │   ├── cli.py
+│   │   └── config.py
+│   ├── data
+│   │   ├── __init__.py
+│   │   ├── akshare_provider.py
+│   │   ├── base.py
+│   │   ├── cache.py
+│   │   └── tushare_provider.py
+│   ├── filters
+│   │   ├── __init__.py
+│   │   ├── financial_filters.py
+│   │   ├── macd_filters.py
+│   │   ├── ma_filters.py
+│   │   └── score.py
+│   ├── indicators
+│   │   ├── __init__.py
+│   │   ├── macd.py
+│   │   ├── moving_average.py
+│   │   └── resample.py
+│   ├── tests
+│   │   ├── test_financials.py
+│   │   ├── test_macd.py
+│   │   └── test_resample.py
+│   └── utils
+│       ├── logging.py
+│       └── symbols.py
+```
+
+## 备注
+
+- 本工具仅筛选 A 股：SH/SZ/BJ。
+- 日线过滤默认关闭，符合“前三个周期非常好时，日线不用看”的要求。

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,56 @@
+data:
+  provider: akshare  # akshare | tushare | auto
+  tushare_token: ""
+  cache_dir: .cache
+  use_cache: true
+  markets: ["SH", "SZ", "BJ"]
+
+macd:
+  fast: 12
+  slow: 26
+  signal: 9
+
+zero_band:
+  quarter: 0.01
+  month: 0.0
+  week: 0.015
+  daily: 0.0
+
+macd_filters:
+  last_n_q_bars: 2
+  enable_daily_filter: false
+  daily_rule: dif_gt_dea_and_hist_gt_0
+
+market_cap:
+  max_total_market_cap: 1.0e11
+  field: total_market_cap
+
+financial:
+  eps_field_candidates:
+    - 基本每股收益(元)
+    - 基本每股收益
+    - 每股收益
+  net_profit_field_candidates:
+    - 归属于母公司股东的净利润(元)
+    - 归母净利润
+    - 归属母公司股东的净利润
+  require_net_profit_positive: true
+
+moving_average:
+  enabled: true
+  price_above: [20]
+  ma_order: [20, 60]
+
+score_weights:
+  quarter_cross: 2.0
+  month_opening: 1.5
+  week_strength: 1.0
+  ma_strength: 1.0
+
+output:
+  export: ["csv", "xlsx"]
+  output_dir: output
+  html_report: true
+
+max_workers: 8
+log_level: INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+akshare>=1.12.0
+pandas>=2.1.0
+numpy>=1.26.0
+tqdm>=4.66.0
+pyyaml>=6.0.1
+openpyxl>=3.1.2
+pytest>=8.0.0
+tushare>=1.4.0

--- a/screener/__init__.py
+++ b/screener/__init__.py
@@ -1,0 +1,4 @@
+"""A-share stock screener package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/screener/__main__.py
+++ b/screener/__main__.py
@@ -1,0 +1,4 @@
+from screener.app.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/screener/app/__init__.py
+++ b/screener/app/__init__.py
@@ -1,0 +1,3 @@
+from screener.app.cli import main
+
+__all__ = ["main"]

--- a/screener/app/cli.py
+++ b/screener/app/cli.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import argparse
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pandas as pd
+from tqdm import tqdm
+
+from screener.app.config import AppConfig, load_config
+from screener.data import AkshareProvider, TushareProvider
+from screener.data.cache import CacheManager
+from screener.filters import (
+    daily_filter,
+    latest_quarter_eps,
+    month_filter,
+    moving_average_filter,
+    quarter_filter,
+    score_signal,
+    week_filter,
+)
+from screener.indicators.macd import macd
+from screener.indicators.moving_average import moving_averages
+from screener.indicators.resample import resample_ohlcv
+from screener.utils.logging import setup_logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _select_provider(config: AppConfig):
+    if config.data.provider == "tushare" and config.data.tushare_token:
+        return TushareProvider(config.data.tushare_token)
+    if config.data.provider == "auto" and config.data.tushare_token:
+        return TushareProvider(config.data.tushare_token)
+    return AkshareProvider()
+
+
+def _export_results(df: pd.DataFrame, config: AppConfig) -> None:
+    output_dir = Path(config.output.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if "csv" in config.output.export:
+        df.to_csv(output_dir / "screener_results.csv", index=False)
+    if "xlsx" in config.output.export:
+        df.to_excel(output_dir / "screener_results.xlsx", index=False)
+    if config.output.html_report:
+        html = df.to_html(index=False)
+        (output_dir / "screener_results.html").write_text(html, encoding="utf-8")
+
+
+def _load_cached(cache: CacheManager, key: str, use_cache: bool) -> pd.DataFrame | None:
+    if not use_cache:
+        return None
+    return cache.read(key)
+
+
+def _store_cached(cache: CacheManager, key: str, data: pd.DataFrame, use_cache: bool) -> None:
+    if use_cache:
+        cache.write(key, data)
+
+
+def _process_symbol(
+    symbol_row: pd.Series,
+    config: AppConfig,
+    provider,
+    cache: CacheManager,
+    market_caps: dict,
+) -> dict | None:
+    symbol = symbol_row["code"]
+    name = symbol_row["name"]
+    market = symbol_row["market"]
+
+    daily_key = f"daily_{symbol}"
+    daily_data = _load_cached(cache, daily_key, config.data.use_cache)
+    if daily_data is None:
+        daily_data = provider.daily_history(symbol)
+        _store_cached(cache, daily_key, daily_data, config.data.use_cache)
+    if daily_data is None or daily_data.empty:
+        return None
+
+    daily_data = daily_data.sort_values("date")
+    weekly = resample_ohlcv(daily_data, "W-FRI")
+    monthly = resample_ohlcv(daily_data, "M")
+    quarterly = resample_ohlcv(daily_data, "Q")
+
+    if len(quarterly) < 3 or len(monthly) < 3 or len(weekly) < 3:
+        return None
+
+    quarter_macd = macd(quarterly["close"], config.macd.fast, config.macd.slow, config.macd.signal)
+    month_macd = macd(monthly["close"], config.macd.fast, config.macd.slow, config.macd.signal)
+    week_macd = macd(weekly["close"], config.macd.fast, config.macd.slow, config.macd.signal)
+    daily_macd = macd(daily_data["close"], config.macd.fast, config.macd.slow, config.macd.signal)
+
+    quarter_result = quarter_filter(quarter_macd, quarterly["close"], config.zero_band, config.macd_filters)
+    if not quarter_result["pass"]:
+        return None
+    month_result = month_filter(month_macd, monthly["close"], config.zero_band)
+    if not month_result["pass"]:
+        return None
+    week_result = week_filter(week_macd, weekly["close"], config.zero_band)
+    if not week_result["pass"]:
+        return None
+    if config.macd_filters.enable_daily_filter:
+        daily_result = daily_filter(daily_macd, daily_data["close"], config.zero_band, config.macd_filters)
+        if not daily_result["pass"]:
+            return None
+    else:
+        daily_result = daily_filter(daily_macd, daily_data["close"], config.zero_band, config.macd_filters)
+
+    ma_windows = sorted(set(config.moving_average.price_above + config.moving_average.ma_order))
+    ma_data = moving_averages(daily_data["close"], ma_windows)
+    ma_result = moving_average_filter(daily_data["close"], ma_data, config.moving_average)
+    if not ma_result["pass"]:
+        return None
+
+    cap_value = market_caps.get(symbol)
+    if cap_value is None or cap_value >= config.market_cap.max_total_market_cap:
+        return None
+
+    fin_key = f"fin_{symbol}"
+    fin_data = _load_cached(cache, fin_key, config.data.use_cache)
+    if fin_data is None:
+        fin_data = provider.quarterly_financials(symbol)
+        _store_cached(cache, fin_key, fin_data, config.data.use_cache)
+    fin_result = latest_quarter_eps(fin_data, config.financial)
+    if not fin_result.get("pass"):
+        return None
+
+    score = score_signal(quarter_result, month_result, week_result, ma_result, config.score_weights)
+
+    return {
+        "code": symbol,
+        "name": name,
+        "market": market,
+        "total_market_cap": cap_value,
+        "quarter_DIF": quarter_result["DIF"],
+        "quarter_DEA": quarter_result["DEA"],
+        "quarter_HIST": quarter_result["HIST"],
+        "quarter_norm_dif": quarter_result["norm_dif"],
+        "quarter_norm_dea": quarter_result["norm_dea"],
+        "quarter_cross": quarter_result["cross"],
+        "quarter_cross_bars_ago": quarter_result["cross_bars_ago"],
+        "month_DIF": month_result["DIF"],
+        "month_DEA": month_result["DEA"],
+        "month_HIST": month_result["HIST"],
+        "month_norm_dif": month_result["norm_dif"],
+        "month_norm_dea": month_result["norm_dea"],
+        "month_opening": month_result["opening"],
+        "week_DIF": week_result["DIF"],
+        "week_DEA": week_result["DEA"],
+        "week_HIST": week_result["HIST"],
+        "week_norm_dif": week_result["norm_dif"],
+        "week_norm_dea": week_result["norm_dea"],
+        "daily_DIF": daily_result["DIF"],
+        "daily_DEA": daily_result["DEA"],
+        "daily_HIST": daily_result["HIST"],
+        "eps_latest": fin_result.get("eps_latest"),
+        "eps_prev": fin_result.get("eps_prev"),
+        "net_profit_latest": fin_result.get("net_profit_latest"),
+        "score": score,
+        **ma_result,
+    }
+
+
+def run(config: AppConfig) -> pd.DataFrame:
+    setup_logging(config.log_level)
+    provider = _select_provider(config)
+    cache = CacheManager(Path(config.data.cache_dir))
+
+    LOGGER.info("Loading stock universe...")
+    universe = provider.list_stocks(config.data.markets)
+    if universe.empty:
+        raise RuntimeError("No stocks returned from provider")
+
+    LOGGER.info("Loading market caps...")
+    market_caps_df = provider.market_caps()
+    market_caps = {}
+    if not market_caps_df.empty:
+        cap_field = config.market_cap.field
+        if cap_field not in market_caps_df.columns:
+            cap_field = "total_market_cap"
+        market_caps = market_caps_df.set_index("code")[cap_field].dropna().to_dict()
+
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=config.max_workers) as executor:
+        futures = [
+            executor.submit(_process_symbol, row, config, provider, cache, market_caps)
+            for _, row in universe.iterrows()
+        ]
+        for future in tqdm(as_completed(futures), total=len(futures)):
+            try:
+                result = future.result()
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.error("Processing failed: %s", exc)
+                continue
+            if result:
+                results.append(result)
+
+    if not results:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(results).sort_values("score", ascending=False)
+    _export_results(df, config)
+    return df
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="A-share stock screener")
+    parser.add_argument("run", nargs="?", default="run")
+    parser.add_argument("--config", required=True, help="Path to config yaml")
+    parser.add_argument("--max-workers", type=int)
+    parser.add_argument("--use-cache", type=str)
+    parser.add_argument("--export", type=str)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    config = load_config(args.config)
+    if args.max_workers is not None:
+        config.max_workers = args.max_workers
+    if args.use_cache is not None:
+        config.data.use_cache = args.use_cache.lower() == "true"
+    if args.export is not None:
+        config.output.export = [item.strip() for item in args.export.split(",") if item.strip()]
+    run(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/screener/app/config.py
+++ b/screener/app/config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class DataConfig:
+    provider: str = "akshare"
+    tushare_token: str | None = None
+    cache_dir: str = ".cache"
+    use_cache: bool = True
+    markets: list[str] = field(default_factory=lambda: ["SH", "SZ", "BJ"])
+
+
+@dataclass
+class MacdConfig:
+    fast: int = 12
+    slow: int = 26
+    signal: int = 9
+
+
+@dataclass
+class ZeroBandConfig:
+    quarter: float = 0.01
+    month: float = 0.0
+    week: float = 0.015
+    daily: float = 0.0
+
+
+@dataclass
+class MacdFilterConfig:
+    last_n_q_bars: int = 2
+    enable_daily_filter: bool = False
+    daily_rule: str = "dif_gt_dea_and_hist_gt_0"
+
+
+@dataclass
+class MarketCapConfig:
+    max_total_market_cap: float = 1e11
+    field: str = "total_market_cap"
+
+
+@dataclass
+class FinancialConfig:
+    eps_field_candidates: list[str] = field(
+        default_factory=lambda: [
+            "基本每股收益(元)",
+            "基本每股收益",
+            "每股收益",  # fallback
+        ]
+    )
+    net_profit_field_candidates: list[str] = field(
+        default_factory=lambda: [
+            "归属于母公司股东的净利润(元)",
+            "归母净利润",
+            "归属母公司股东的净利润",
+        ]
+    )
+    require_net_profit_positive: bool = True
+
+
+@dataclass
+class MovingAverageConfig:
+    enabled: bool = True
+    price_above: list[int] = field(default_factory=lambda: [20])
+    ma_order: list[int] = field(default_factory=lambda: [20, 60])
+
+
+@dataclass
+class ScoreWeights:
+    quarter_cross: float = 2.0
+    month_opening: float = 1.5
+    week_strength: float = 1.0
+    ma_strength: float = 1.0
+
+
+@dataclass
+class OutputConfig:
+    export: list[str] = field(default_factory=lambda: ["csv"])
+    output_dir: str = "output"
+    html_report: bool = True
+
+
+@dataclass
+class AppConfig:
+    data: DataConfig = field(default_factory=DataConfig)
+    macd: MacdConfig = field(default_factory=MacdConfig)
+    zero_band: ZeroBandConfig = field(default_factory=ZeroBandConfig)
+    macd_filters: MacdFilterConfig = field(default_factory=MacdFilterConfig)
+    market_cap: MarketCapConfig = field(default_factory=MarketCapConfig)
+    financial: FinancialConfig = field(default_factory=FinancialConfig)
+    moving_average: MovingAverageConfig = field(default_factory=MovingAverageConfig)
+    score_weights: ScoreWeights = field(default_factory=ScoreWeights)
+    output: OutputConfig = field(default_factory=OutputConfig)
+    max_workers: int = 8
+    log_level: str = "INFO"
+
+
+def _deep_update(target: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    for key, value in source.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            target[key] = _deep_update(target[key], value)
+        else:
+            target[key] = value
+    return target
+
+
+def load_config(path: str | Path) -> AppConfig:
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+    data = _deep_update(AppConfig().__dict__, raw)
+
+    return AppConfig(
+        data=DataConfig(**data.get("data", {})),
+        macd=MacdConfig(**data.get("macd", {})),
+        zero_band=ZeroBandConfig(**data.get("zero_band", {})),
+        macd_filters=MacdFilterConfig(**data.get("macd_filters", {})),
+        market_cap=MarketCapConfig(**data.get("market_cap", {})),
+        financial=FinancialConfig(**data.get("financial", {})),
+        moving_average=MovingAverageConfig(**data.get("moving_average", {})),
+        score_weights=ScoreWeights(**data.get("score_weights", {})),
+        output=OutputConfig(**data.get("output", {})),
+        max_workers=data.get("max_workers", 8),
+        log_level=data.get("log_level", "INFO"),
+    )

--- a/screener/data/__init__.py
+++ b/screener/data/__init__.py
@@ -1,0 +1,5 @@
+from screener.data.akshare_provider import AkshareProvider
+from screener.data.base import DataProvider
+from screener.data.tushare_provider import TushareProvider
+
+__all__ = ["AkshareProvider", "TushareProvider", "DataProvider"]

--- a/screener/data/akshare_provider.py
+++ b/screener/data/akshare_provider.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+from screener.data.base import DataProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AkshareProvider(DataProvider):
+    def __init__(self) -> None:
+        try:
+            import akshare as ak  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency runtime
+            raise RuntimeError("AkShare is required. Please install akshare.") from exc
+        self.ak = ak
+
+    def list_stocks(self, markets: list[str]) -> pd.DataFrame:
+        data = self.ak.stock_info_a_code_name()
+        data = data.rename(columns={"code": "code", "name": "name"})
+        data["market"] = data["code"].str[0].map({"6": "SH", "0": "SZ", "3": "SZ", "8": "BJ"})
+        data = data[data["market"].isin(markets)].copy()
+        data["symbol"] = data["code"]
+        return data[["symbol", "code", "name", "market"]]
+
+    def daily_history(self, symbol: str) -> pd.DataFrame:
+        try:
+            data = self.ak.stock_zh_a_hist(symbol=symbol, period="daily", adjust="qfq")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("AkShare daily history failed for %s: %s", symbol, exc)
+            return pd.DataFrame()
+        if data.empty:
+            return data
+        data = data.rename(
+            columns={
+                "日期": "date",
+                "开盘": "open",
+                "收盘": "close",
+                "最高": "high",
+                "最低": "low",
+                "成交量": "volume",
+                "成交额": "amount",
+            }
+        )
+        data["date"] = pd.to_datetime(data["date"])
+        return data[["date", "open", "high", "low", "close", "volume", "amount"]]
+
+    def market_caps(self) -> pd.DataFrame:
+        try:
+            data = self.ak.stock_zh_a_spot_em()
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("AkShare spot failed: %s", exc)
+            return pd.DataFrame()
+        columns_map = {
+            "代码": "code",
+            "名称": "name",
+            "总市值": "total_market_cap",
+            "流通市值": "float_market_cap",
+        }
+        data = data.rename(columns=columns_map)
+        data["total_market_cap"] = pd.to_numeric(data.get("total_market_cap"), errors="coerce")
+        data["float_market_cap"] = pd.to_numeric(data.get("float_market_cap"), errors="coerce")
+        return data[["code", "name", "total_market_cap", "float_market_cap"]]
+
+    def quarterly_financials(self, symbol: str) -> pd.DataFrame:
+        try:
+            data = self.ak.stock_financial_analysis_indicator(symbol=symbol)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("AkShare financials failed for %s: %s", symbol, exc)
+            return pd.DataFrame()
+        if data.empty:
+            return data
+        data = data.rename(columns={"日期": "report_date"})
+        data["report_date"] = pd.to_datetime(data["report_date"], errors="coerce")
+        return data

--- a/screener/data/base.py
+++ b/screener/data/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+
+class DataProvider(ABC):
+    @abstractmethod
+    def list_stocks(self, markets: list[str]) -> pd.DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def daily_history(self, symbol: str) -> pd.DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def market_caps(self) -> pd.DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def quarterly_financials(self, symbol: str) -> pd.DataFrame:
+        raise NotImplementedError

--- a/screener/data/cache.py
+++ b/screener/data/cache.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class CacheManager:
+    base_dir: Path
+
+    def __post_init__(self) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def read(self, key: str) -> pd.DataFrame | None:
+        path = self.base_dir / f"{key}.csv"
+        if not path.exists():
+            return None
+        return pd.read_csv(path)
+
+    def write(self, key: str, data: pd.DataFrame) -> None:
+        path = self.base_dir / f"{key}.csv"
+        data.to_csv(path, index=False)

--- a/screener/data/tushare_provider.py
+++ b/screener/data/tushare_provider.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+from screener.data.base import DataProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TushareProvider(DataProvider):
+    def __init__(self, token: str) -> None:
+        try:
+            import tushare as ts  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency runtime
+            raise RuntimeError("Tushare is required. Please install tushare.") from exc
+        ts.set_token(token)
+        self.pro = ts.pro_api()
+
+    def list_stocks(self, markets: list[str]) -> pd.DataFrame:
+        data = self.pro.stock_basic(exchange="", list_status="L", fields="ts_code,symbol,name,market")
+        data = data.rename(columns={"ts_code": "symbol", "symbol": "code", "name": "name"})
+        data["market"] = data["symbol"].str.split(".").str[1]
+        data = data[data["market"].isin(markets)].copy()
+        return data[["symbol", "code", "name", "market"]]
+
+    def daily_history(self, symbol: str) -> pd.DataFrame:
+        try:
+            data = self.pro.daily(ts_code=f"{symbol}.SH" if symbol.startswith("6") else f"{symbol}.SZ")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Tushare daily failed for %s: %s", symbol, exc)
+            return pd.DataFrame()
+        if data.empty:
+            return data
+        data = data.rename(
+            columns={
+                "trade_date": "date",
+                "open": "open",
+                "close": "close",
+                "high": "high",
+                "low": "low",
+                "vol": "volume",
+                "amount": "amount",
+            }
+        )
+        data["date"] = pd.to_datetime(data["date"], format="%Y%m%d")
+        return data[["date", "open", "high", "low", "close", "volume", "amount"]]
+
+    def market_caps(self) -> pd.DataFrame:
+        try:
+            data = self.pro.daily_basic(ts_code="", fields="ts_code,total_mv,circ_mv")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Tushare market cap failed: %s", exc)
+            return pd.DataFrame()
+        data = data.rename(columns={"ts_code": "symbol", "total_mv": "total_market_cap", "circ_mv": "float_market_cap"})
+        data["code"] = data["symbol"].str.split(".").str[0]
+        data["total_market_cap"] = pd.to_numeric(data["total_market_cap"], errors="coerce") * 1e4
+        data["float_market_cap"] = pd.to_numeric(data["float_market_cap"], errors="coerce") * 1e4
+        return data[["code", "total_market_cap", "float_market_cap"]]
+
+    def quarterly_financials(self, symbol: str) -> pd.DataFrame:
+        try:
+            data = self.pro.fina_indicator(ts_code=f"{symbol}.SH" if symbol.startswith("6") else f"{symbol}.SZ", fields="end_date,eps,netprofit_margin")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Tushare financials failed for %s: %s", symbol, exc)
+            return pd.DataFrame()
+        if data.empty:
+            return data
+        data = data.rename(columns={"end_date": "report_date", "eps": "EPS", "netprofit_margin": "net_profit"})
+        data["report_date"] = pd.to_datetime(data["report_date"], format="%Y%m%d")
+        return data

--- a/screener/filters/__init__.py
+++ b/screener/filters/__init__.py
@@ -1,0 +1,14 @@
+from screener.filters.financial_filters import latest_quarter_eps
+from screener.filters.macd_filters import daily_filter, month_filter, quarter_filter, week_filter
+from screener.filters.ma_filters import moving_average_filter
+from screener.filters.score import score_signal
+
+__all__ = [
+    "latest_quarter_eps",
+    "daily_filter",
+    "month_filter",
+    "quarter_filter",
+    "week_filter",
+    "moving_average_filter",
+    "score_signal",
+]

--- a/screener/filters/financial_filters.py
+++ b/screener/filters/financial_filters.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from screener.app.config import FinancialConfig
+
+
+def _first_existing(columns: list[str], candidates: list[str]) -> str | None:
+    for name in candidates:
+        if name in columns:
+            return name
+    return None
+
+
+def latest_quarter_eps(financials: pd.DataFrame, config: FinancialConfig) -> dict:
+    if financials.empty:
+        return {"pass": False, "reason": "no_financials"}
+    frame = financials.copy()
+    frame = frame.sort_values("report_date", ascending=False)
+    eps_col = _first_existing(frame.columns.tolist(), config.eps_field_candidates + ["EPS", "eps"])
+    profit_col = _first_existing(frame.columns.tolist(), config.net_profit_field_candidates + ["net_profit"])
+    if eps_col is None:
+        return {"pass": False, "reason": "no_eps"}
+    latest = frame.iloc[0]
+    prev = frame.iloc[1] if len(frame) > 1 else None
+    eps_latest = pd.to_numeric(latest[eps_col], errors="coerce")
+    eps_prev = pd.to_numeric(prev[eps_col], errors="coerce") if prev is not None else None
+    if pd.isna(eps_latest) or eps_prev is None or pd.isna(eps_prev):
+        return {"pass": False, "reason": "eps_missing"}
+    pass_eps = eps_latest > eps_prev and eps_latest > 0
+    net_profit_latest = None
+    if profit_col is not None:
+        net_profit_latest = pd.to_numeric(latest[profit_col], errors="coerce")
+        if config.require_net_profit_positive and pd.notna(net_profit_latest):
+            pass_eps = pass_eps and net_profit_latest > 0
+    return {
+        "pass": pass_eps,
+        "eps_latest": float(eps_latest),
+        "eps_prev": float(eps_prev),
+        "net_profit_latest": float(net_profit_latest) if net_profit_latest is not None and pd.notna(net_profit_latest) else None,
+        "reason": "ok" if pass_eps else "eps_or_profit_failed",
+    }

--- a/screener/filters/ma_filters.py
+++ b/screener/filters/ma_filters.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from screener.app.config import MovingAverageConfig
+
+
+def moving_average_filter(close: pd.Series, ma_df: pd.DataFrame, config: MovingAverageConfig) -> dict:
+    if not config.enabled:
+        return {"pass": True, "reason": "disabled"}
+    last_close = close.iloc[-1]
+    pass_price = True
+    for window in config.price_above:
+        key = f"MA{window}"
+        if key in ma_df.columns and pd.notna(ma_df[key].iloc[-1]):
+            pass_price = pass_price and last_close > ma_df[key].iloc[-1]
+    pass_order = True
+    if len(config.ma_order) >= 2:
+        for left, right in zip(config.ma_order, config.ma_order[1:]):
+            left_key = f"MA{left}"
+            right_key = f"MA{right}"
+            if left_key in ma_df.columns and right_key in ma_df.columns:
+                pass_order = pass_order and ma_df[left_key].iloc[-1] > ma_df[right_key].iloc[-1]
+    return {
+        "pass": pass_price and pass_order,
+        "last_close": float(last_close),
+        **{k: float(v.iloc[-1]) for k, v in ma_df.items()},
+    }

--- a/screener/filters/macd_filters.py
+++ b/screener/filters/macd_filters.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from screener.app.config import MacdFilterConfig, ZeroBandConfig
+from screener.indicators.macd import detect_cross
+
+
+def normalize_macd(macd_df: pd.DataFrame, close: pd.Series) -> pd.DataFrame:
+    data = macd_df.copy()
+    data["norm_dif"] = data["DIF"] / close
+    data["norm_dea"] = data["DEA"] / close
+    return data
+
+
+def quarter_filter(macd_df: pd.DataFrame, close: pd.Series, zero_band: ZeroBandConfig, settings: MacdFilterConfig) -> dict:
+    normalized = normalize_macd(macd_df, close)
+    last_row = normalized.iloc[-1]
+    cross, bars_ago = detect_cross(macd_df, lookback=settings.last_n_q_bars)
+    condition = (
+        last_row["norm_dif"] >= -zero_band.quarter
+        and last_row["norm_dea"] >= -zero_band.quarter
+        and cross
+    )
+    return {
+        "pass": condition,
+        "norm_dif": last_row["norm_dif"],
+        "norm_dea": last_row["norm_dea"],
+        "cross": cross,
+        "cross_bars_ago": bars_ago,
+        "DIF": last_row["DIF"],
+        "DEA": last_row["DEA"],
+        "HIST": last_row["HIST"],
+    }
+
+
+def month_filter(macd_df: pd.DataFrame, close: pd.Series, zero_band: ZeroBandConfig) -> dict:
+    normalized = normalize_macd(macd_df, close)
+    last_row = normalized.iloc[-1]
+    prev_row = normalized.iloc[-2] if len(normalized) > 1 else last_row
+    hist_expand = last_row["HIST"] > prev_row["HIST"]
+    condition = (
+        last_row["norm_dif"] > 0
+        and last_row["norm_dea"] > 0
+        and last_row["HIST"] > 0
+        and hist_expand
+    )
+    return {
+        "pass": condition,
+        "norm_dif": last_row["norm_dif"],
+        "norm_dea": last_row["norm_dea"],
+        "opening": hist_expand,
+        "DIF": last_row["DIF"],
+        "DEA": last_row["DEA"],
+        "HIST": last_row["HIST"],
+    }
+
+
+def week_filter(macd_df: pd.DataFrame, close: pd.Series, zero_band: ZeroBandConfig) -> dict:
+    normalized = normalize_macd(macd_df, close)
+    last_row = normalized.iloc[-1]
+    condition = (
+        last_row["norm_dif"] >= -zero_band.week and last_row["norm_dea"] >= -zero_band.week
+    )
+    return {
+        "pass": condition,
+        "norm_dif": last_row["norm_dif"],
+        "norm_dea": last_row["norm_dea"],
+        "DIF": last_row["DIF"],
+        "DEA": last_row["DEA"],
+        "HIST": last_row["HIST"],
+    }
+
+
+def daily_filter(macd_df: pd.DataFrame, close: pd.Series, zero_band: ZeroBandConfig, settings: MacdFilterConfig) -> dict:
+    normalized = normalize_macd(macd_df, close)
+    last_row = normalized.iloc[-1]
+    condition = True
+    if settings.daily_rule == "dif_gt_dea_and_hist_gt_0":
+        condition = last_row["DIF"] > last_row["DEA"] and last_row["HIST"] > 0
+    return {
+        "pass": condition,
+        "norm_dif": last_row["norm_dif"],
+        "norm_dea": last_row["norm_dea"],
+        "DIF": last_row["DIF"],
+        "DEA": last_row["DEA"],
+        "HIST": last_row["HIST"],
+    }

--- a/screener/filters/score.py
+++ b/screener/filters/score.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from screener.app.config import ScoreWeights
+
+
+def score_signal(quarter: dict, month: dict, week: dict, ma: dict, weights: ScoreWeights) -> float:
+    score = 0.0
+    if quarter.get("cross"):
+        bars = quarter.get("cross_bars_ago", 0) or 0
+        score += weights.quarter_cross * max(0.0, 1.0 - 0.3 * bars)
+    if month.get("opening"):
+        score += weights.month_opening * (1.0 + max(0.0, month.get("HIST", 0)))
+    score += weights.week_strength * max(0.0, week.get("norm_dif", 0))
+    if ma.get("pass"):
+        score += weights.ma_strength
+    return round(score, 4)

--- a/screener/indicators/__init__.py
+++ b/screener/indicators/__init__.py
@@ -1,0 +1,5 @@
+from screener.indicators.macd import detect_cross, macd
+from screener.indicators.moving_average import moving_averages
+from screener.indicators.resample import resample_ohlcv
+
+__all__ = ["macd", "detect_cross", "moving_averages", "resample_ohlcv"]

--- a/screener/indicators/macd.py
+++ b/screener/indicators/macd.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def macd(series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.DataFrame:
+    ema_fast = series.ewm(span=fast, adjust=False).mean()
+    ema_slow = series.ewm(span=slow, adjust=False).mean()
+    dif = ema_fast - ema_slow
+    dea = dif.ewm(span=signal, adjust=False).mean()
+    hist = dif - dea
+    return pd.DataFrame({"DIF": dif, "DEA": dea, "HIST": hist})
+
+
+def detect_cross(macd_df: pd.DataFrame, lookback: int = 2) -> tuple[bool, int | None]:
+    if macd_df.empty or len(macd_df) < 2:
+        return False, None
+    dif = macd_df["DIF"]
+    dea = macd_df["DEA"]
+    cross_points = (dif.shift(1) <= dea.shift(1)) & (dif > dea)
+    recent_index = cross_points.tail(lookback)
+    if recent_index.any():
+        last_pos = recent_index[recent_index].index[-1]
+        bars_ago = len(macd_df) - 1 - macd_df.index.get_loc(last_pos)
+        return True, bars_ago
+    return False, None

--- a/screener/indicators/moving_average.py
+++ b/screener/indicators/moving_average.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def moving_averages(series: pd.Series, windows: list[int]) -> pd.DataFrame:
+    data = {}
+    for window in windows:
+        data[f"MA{window}"] = series.rolling(window=window).mean()
+    return pd.DataFrame(data)

--- a/screener/indicators/resample.py
+++ b/screener/indicators/resample.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+AGG_MAP = {
+    "open": "first",
+    "high": "max",
+    "low": "min",
+    "close": "last",
+    "volume": "sum",
+    "amount": "sum",
+}
+
+
+def resample_ohlcv(data: pd.DataFrame, rule: str) -> pd.DataFrame:
+    if data.empty:
+        return data
+    frame = data.copy()
+    frame = frame.set_index("date").sort_index()
+    resampled = frame.resample(rule).agg(AGG_MAP).dropna(subset=["close"])
+    resampled = resampled.reset_index()
+    return resampled

--- a/screener/tests/test_financials.py
+++ b/screener/tests/test_financials.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from screener.app.config import FinancialConfig
+from screener.filters.financial_filters import latest_quarter_eps
+
+
+def test_eps_growth_positive():
+    data = pd.DataFrame(
+        {
+            "report_date": pd.to_datetime(["2024-06-30", "2024-03-31"]),
+            "基本每股收益(元)": [0.5, 0.2],
+            "归属于母公司股东的净利润(元)": [10.0, 5.0],
+        }
+    )
+    result = latest_quarter_eps(data, FinancialConfig())
+    assert result["pass"] is True
+    assert result["eps_latest"] == 0.5
+
+
+def test_eps_growth_fail():
+    data = pd.DataFrame(
+        {
+            "report_date": pd.to_datetime(["2024-06-30", "2024-03-31"]),
+            "基本每股收益(元)": [0.1, 0.2],
+        }
+    )
+    result = latest_quarter_eps(data, FinancialConfig())
+    assert result["pass"] is False

--- a/screener/tests/test_macd.py
+++ b/screener/tests/test_macd.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from screener.indicators.macd import detect_cross, macd
+
+
+def test_detect_cross_recent():
+    series = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    macd_df = macd(series)
+    crossed, bars_ago = detect_cross(macd_df, lookback=5)
+    assert crossed is True
+    assert bars_ago is not None
+
+
+def test_detect_cross_none():
+    series = pd.Series([10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+    macd_df = macd(series)
+    crossed, bars_ago = detect_cross(macd_df, lookback=2)
+    assert crossed is False
+    assert bars_ago is None

--- a/screener/tests/test_resample.py
+++ b/screener/tests/test_resample.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from screener.indicators.resample import resample_ohlcv
+
+
+def test_resample_weekly():
+    dates = pd.date_range("2024-01-01", periods=10, freq="D")
+    data = pd.DataFrame(
+        {
+            "date": dates,
+            "open": range(10),
+            "high": range(1, 11),
+            "low": range(10),
+            "close": range(10),
+            "volume": range(10),
+            "amount": range(10),
+        }
+    )
+    weekly = resample_ohlcv(data, "W-FRI")
+    assert not weekly.empty
+    assert "close" in weekly.columns

--- a/screener/utils/__init__.py
+++ b/screener/utils/__init__.py
@@ -1,0 +1,4 @@
+from screener.utils.logging import setup_logging
+from screener.utils.symbols import StockSymbol, is_a_share, normalize_symbol
+
+__all__ = ["setup_logging", "StockSymbol", "is_a_share", "normalize_symbol"]

--- a/screener/utils/logging.py
+++ b/screener/utils/logging.py
@@ -1,0 +1,10 @@
+import logging
+import sys
+
+
+def setup_logging(level: str = "INFO") -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )

--- a/screener/utils/symbols.py
+++ b/screener/utils/symbols.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StockSymbol:
+    code: str
+    name: str
+    market: str
+
+
+def normalize_symbol(code: str) -> str:
+    return code.strip().upper()
+
+
+def is_a_share(code: str) -> bool:
+    upper = normalize_symbol(code)
+    return upper.endswith(".SH") or upper.endswith(".SZ") or upper.endswith(".BJ")


### PR DESCRIPTION
### Motivation

- Provide a configurable, production-friendly A-share (SH/SZ/BJ) stock screener implementing the requested multi-period MACD, EPS growth and MA filters. 
- Support both AkShare (default) and Tushare (optional with token) as data providers and avoid re-downloading via caching. 
- Make the screening pipeline robust to missing/partial data, delisted/paused symbols and network errors. 
- Expose a CLI entrypoint and configurable parameters so rules/thresholds can be tuned via YAML.

### Description

- Add a new `screener` package with layered modules for data providers (`AkshareProvider`, `TushareProvider`), caching (`CacheManager`), indicators (`macd`, `moving_averages`, `resample_ohlcv`), filters (`quarter_filter`, `month_filter`, `week_filter`, `daily_filter`, `latest_quarter_eps`, `moving_average_filter`) and scoring (`score_signal`).
- Implement the main CLI runner at `screener.app.cli` which loads `AppConfig` from YAML, selects provider, parallelizes symbol processing via `ThreadPoolExecutor`, applies the MACD/MA/financial filters, computes a configurable score, and exports results to CSV/XLSX/HTML. 
- Add configuration schema and loader (`screener.app.config`) and a `config.example.yaml` with defaults for MACD params, zero-band thresholds, market cap limits, EPS field mappings, MA rules and output settings. 
- Include engineering items: CSV cache under `.cache`, logging setup, progress bars (`tqdm`), `requirements.txt`, `README.md` with usage and data-field notes, and unit tests for MACD cross detection, resampling and EPS growth logic under `screener/tests`.

### Testing

- Added pytest unit tests: `screener/tests/test_macd.py`, `screener/tests/test_resample.py`, and `screener/tests/test_financials.py` which validate MACD cross detection, OHLCV resampling and EPS growth rules. 
- No automated test run was executed as part of this change; tests were added but not run in CI for this PR. 
- To run tests locally use `pytest` after installing dependencies from `requirements.txt` and activating the virtual environment. 
- Manual smoke usage is documented in `README.md` and the primary runner is `python -m screener run --config config.example.yaml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b1819efc83329a3c35baa3201a85)